### PR TITLE
hotfix: 전시회이미지가 제대로 불러와지지 않는 현상해결

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -64,6 +64,7 @@ app.use(
                 imgSrc: [
                     '\'self\'',
                     'https://res.cloudinary.com/dw57ytzhg/',
+                    'https://res.cloudinary.com/dvkr4k6n8/',
                     'data:',
                     'blob:'
                 ],


### PR DESCRIPTION
- helmet 라이브러리 설정 변경